### PR TITLE
Use XDG_CONFIG_HOME for global config path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,9 +24,13 @@ pub struct Config {
     pub index_warn_threshold: Option<usize>,
 }
 
-/// Return the global config path (`~/.config/vecgrep/config.toml`).
+/// Return the global config path (`$XDG_CONFIG_HOME/vecgrep/config.toml`,
+/// defaulting to `~/.config/vecgrep/config.toml`).
 pub fn global_config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("vecgrep").join("config.toml"))
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
+        .map(|d| d.join("vecgrep").join("config.toml"))
 }
 
 /// Return the project config path (`<project_root>/.vecgrep/config.toml`).


### PR DESCRIPTION
## Summary

- On macOS, `dirs::config_dir()` returns `~/Library/Application Support/`, but the README documents `~/.config/vecgrep/config.toml` and CLI users expect XDG-style paths
- This caused the global config file to be silently ignored on macOS when placed at the documented path
- Now respects `$XDG_CONFIG_HOME` if set, falling back to `~/.config/`

## Test plan

- [x] `cargo test config::tests` — all 8 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified `quiet = true` in `~/.config/vecgrep/config.toml` is picked up at runtime