### PR TITLE
Fix first run on unindexed project returning no results

### DIFF
--- a/.direnv/flake-profile
+++ b/.direnv/flake-profile
@@ -1,0 +1,1 @@
+flake-profile-1-link

--- a/.direnv/flake-profile-1-link
+++ b/.direnv/flake-profile-1-link
@@ -1,0 +1,1 @@
+/nix/store/wbdkkr9h9rqh258dm83fr3s3hrpgrdkw-nix-shell-env

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764521362,
+        "narHash": "sha256-M101xMtWdF1eSD0xhiR8nG8CXRlHmv6V+VoY65Smwf4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "871b9fd269ff6246794583ce4ee1031e1da71895",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/25.11";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+            overlays = [ ];
+          };
+        in
+        {
+          devShells.default =
+            with pkgs;
+            mkShell {
+              buildInputs =
+                [
+                  # Rust
+                  cargo-generate
+                  cargo-watch
+                  rustup
+                  rust-analyzer
+                  lldb
+
+                  iconv
+                ];
+            };
+        });
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,8 @@ fn run() -> Result<bool> {
 
     // Check if config changed
     let config_valid = idx.check_config(&config)?;
-    if !config_valid || args.reindex {
+    let index_was_cleared = !config_valid || args.reindex;
+    if index_was_cleared {
         if !config_valid {
             status!(quiet, "Index configuration changed, rebuilding...");
         }
@@ -397,7 +398,19 @@ fn run() -> Result<bool> {
         return Ok(true);
     }
 
-    // CLI: search with current index (immediate results from cached data)
+    // If the index is empty (first run or config change), build it before searching
+    if !indexer.indexing_done && (index_was_cleared || idx.chunk_count()? == 0) {
+        status!(quiet, "Building index before first search...");
+        indexer.drain_all(&mut embedder, &idx, |indexed_so_far| {
+            if !quiet && std::io::stderr().is_terminal() {
+                eprint!("\rIndexed {} files...", indexed_so_far);
+            }
+            Ok(true)
+        })?;
+        finish_indexing(&mut indexer, &idx, &walk_prefix, quiet, &mut walker_handle)?;
+    }
+
+    // CLI: search with current index
     let chunk_count = idx.chunk_count()?;
     status!(quiet, "Index has {} chunks.", chunk_count);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -248,7 +248,7 @@ fn test_default_mode_uses_cached_index() {
 }
 
 #[test]
-fn test_default_mode_without_index_returns_no_results() {
+fn test_first_run_indexes_before_searching() {
     let dir = tempfile::TempDir::new().unwrap();
     std::fs::create_dir(dir.path().join(".git")).unwrap();
     std::fs::write(dir.path().join("new.rs"), "fn brand_new() {}").unwrap();
@@ -259,8 +259,10 @@ fn test_default_mode_without_index_returns_no_results() {
         .output()
         .unwrap();
 
-    // Exit code 1 = no matches found
-    assert_eq!(output.status.code(), Some(1));
+    // First run should build the index and find results
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("brand_new"), "expected match in stdout: {stdout}");
 }
 
 // --- Embedding dimension tests ---


### PR DESCRIPTION
## Summary

- On first run (or after config change), vecgrep searched an empty index and returned no results, then indexed files afterward
- Now detects when the index is empty or was just cleared and builds it before searching, so the first invocation returns results
- Updated the integration test to verify first-run search works

Closes #1

## Test plan

- [x] `cargo test` — all 14 integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] New test `test_first_run_indexes_before_searching` verifies the fix