### PR TITLE
Fix --reindex clearing the index without rebuilding it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -498,7 +498,7 @@ fn run() -> Result<bool> {
     let query = match &args.query {
         Some(q) => q.clone(),
         None if args.interactive => String::new(),
-        None if args.serve || args.index_only || args.stats => String::new(),
+        None if args.serve || args.index_only || args.stats || args.reindex => String::new(),
         None => return Ok(true),
     };
 
@@ -556,8 +556,8 @@ fn run() -> Result<bool> {
         )?;
     }
 
-    // Handle --index-only
-    if args.index_only {
+    // Handle --index-only and --reindex (both index then exit)
+    if args.index_only || args.reindex {
         let stats = idx.stats()?;
         output::print_stats(
             stats.file_count,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -780,3 +780,37 @@ fn test_search_from_subdirectory_shows_relative_paths() {
         "path should be relative to cwd (src/), not project root, got: {stdout}"
     );
 }
+
+#[test]
+fn test_reindex_actually_indexes_files() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join(".git")).unwrap();
+    std::fs::write(dir.path().join("hello.rs"), "fn hello_world() {}").unwrap();
+    std::fs::write(dir.path().join("goodbye.rs"), "fn goodbye_world() {}").unwrap();
+
+    // First, build an initial index
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_vecgrep"))
+        .args(["--index-only"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("Files:  2"),
+        "initial index should have 2 files, got: {stderr}"
+    );
+
+    // Now reindex — should rebuild and still have 2 files
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_vecgrep"))
+        .args(["--reindex"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("Files:  2"),
+        "reindex should report 2 files in stats, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- `--reindex` was a no-op: `rebuild_for_config()` cleared the cache, then the function hit an early return before `drain_all()` could re-embed anything, leaving an empty index
- Added `args.reindex` to the query guard so indexing proceeds, and to the exit block so it emits stats on completion (same as `--index-only`)

## Test plan
- [x] Added `test_reindex_actually_indexes_files` integration test
- [ ] Manual: run `vecgrep --reindex` on a project and verify files are re-indexed and stats are printed