### PR TITLE
Fix tokenizer padding inflating chunk token counts

### DIFF
--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -124,15 +124,15 @@ mod tests {
 
     fn make_tokenizer() -> Tokenizer {
         let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/models/tokenizer.json"));
-        Tokenizer::from_bytes(bytes).unwrap()
+        let mut tok = Tokenizer::from_bytes(bytes).unwrap();
+        tok.with_padding(None);
+        tok
     }
 
     #[test]
     fn test_small_file_single_chunk() {
         let tokenizer = make_tokenizer();
         let content = "hello world\nthis is a test";
-        // Note: tokenizer pads each line to 128 tokens, so 2 lines = 256 padded tokens.
-        // Use chunk_size=500 (the production default) to ensure single-chunk output.
         let chunks = chunk_file("test.txt", content, 500, 50, Some(&tokenizer));
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].start_line, 1);
@@ -216,8 +216,7 @@ mod tests {
     #[test]
     fn test_chunks_overlap_and_cover_file() {
         let tokenizer = make_tokenizer();
-        // Tokenizer pads each line to 128 tokens, so use large chunk_size/overlap
-        // to fit multiple lines per chunk and ensure overlap manifests.
+        // Use enough lines and small enough chunk_size to ensure multiple chunks with overlap.
         let lines: Vec<String> = (0..200)
             .map(|i| format!("Line {} with some extra content to consume tokens", i))
             .collect();

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -46,8 +46,11 @@ impl Embedder {
             .commit_from_memory(MODEL_BYTES)
             .map_err(|e| anyhow::anyhow!("Failed to load ONNX model: {}", e))?;
 
-        let tokenizer = Tokenizer::from_bytes(TOKENIZER_BYTES)
+        let mut tokenizer = Tokenizer::from_bytes(TOKENIZER_BYTES)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
+        // Disable padding so token counts reflect actual content length.
+        // The embedder handles its own padding when building input tensors.
+        tokenizer.with_padding(None);
 
         Ok(Embedder::Local(Box::new(LocalEmbedder {
             session,


### PR DESCRIPTION
## Summary

The all-MiniLM-L6-v2 tokenizer ships with padding enabled (pad to 128 tokens). The chunker uses `tok.encode(line).get_ids().len()` to count tokens per line, and the padding meant every line — even an empty one — counted as 128 tokens. This caused two problems:

**Aggressive over-chunking:** A 10-line file measured as 1,280 tokens (10 × 128), far exceeding the default `chunk_size` of 500. Files that should have been a single chunk were split into 3–4 line fragments.

**Empty chunks dominating search results:** Trailing blank lines became their own chunks with `text: ""`. All empty strings produce the same embedding vector, so they all scored identically against any query (~0.41 cosine similarity). A vault with many short template files (e.g. hundreds of stub notes) would accumulate hundreds of these identical empty chunks. Since 0.41 exceeds the default threshold of 0.3, they filled the entire top-k, drowning out real matches — even when the real content scored lower for a vague query like "help".

**Fix:** Disable padding on the tokenizer after loading it. The embedder already handles its own padding when building input tensors for the ONNX model (manually constructing `attention_mask` and zero-filling in `embed_batch`), so the tokenizer-level padding was purely redundant. With it removed, token counts reflect actual content length, small files stay as single chunks, and empty lines contribute 0 tokens instead of 128.

## Test plan

- [x] All 120 unit tests pass
- [ ] Run `vecgrep --clear-cache "help" .` on a vault with many short/stub files — verify no empty-text results dominate
- [ ] Run `vecgrep --clear-cache "rust programming" .` — verify small files appear as single chunks (start_line=1) rather than fragmented
- [ ] Verify `--stats` shows significantly fewer chunks for the same corpus (fewer fragments = better)